### PR TITLE
Fixed the Aurora Version and amazonlinux image version

### DIFF
--- a/auroraglobaldb_eks.sh
+++ b/auroraglobaldb_eks.sh
@@ -18,6 +18,14 @@ function install_jq()
 function install_packages()
 {
     print_line
+    echo "Increasing size of the cloud9 storage"
+    print_line
+
+    curl -s https://raw.githubusercontent.com/aws-samples/aws-swb-cloud9-init/mainline/cloud9-resize.sh > /tmp/cloud9-resize.sh
+    chmod +x /tmp/cloud9-resize.sh
+    /tmp/cloud9-resize.sh
+
+    print_line
     echo "Installing aws cli v2"
     print_line
     current_dir=`pwd`
@@ -32,13 +40,6 @@ function install_packages()
     sudo ./aws/install --update > ${TERM1} 2>&1
     cd $current_dir
 
-    print_line
-    echo "Increasing size of the cloud9 storage"
-    print_line
-
-    curl -s https://raw.githubusercontent.com/aws-samples/aws-swb-cloud9-init/mainline/cloud9-resize.sh > /tmp/cloud9-resize.sh
-    chmod +x /tmp/cloud9-resize.sh
-    /tmp/cloud9-resize.sh
 }
 
 function install_k8s_utilities()

--- a/auroraglobaldb_eks.sh
+++ b/auroraglobaldb_eks.sh
@@ -217,7 +217,9 @@ function deploy_vpc_c9()
     echo "Increasing size of the cloud9 storage"
     print_line
 
-    source <(curl -s https://raw.githubusercontent.com/aws-samples/aws-swb-cloud9-init/mainline/cloud9-resize.sh)
+    curl -s https://raw.githubusercontent.com/aws-samples/aws-swb-cloud9-init/mainline/cloud9-resize.sh > /tmp/cloud9-resize.sh
+    chmod +x /tmp/cloud9-resize.sh
+    /tmp/cloud9-resize.sh
 
     print_line
     echo "Deploying VPC and C9 environment"
@@ -438,7 +440,7 @@ function configure_pgb_lambda()
     rm -rf /tmp/python
     cd /tmp
 
-    pip3 install kubernetes -t python/
+    pip3 install kubernetes --use-feature=2020-resolver -t python/
     zip -r kubernetes.zip python  > /dev/null
     aws lambda publish-layer-version --layer-name ${LAYER_NAME} --zip-file fileb://kubernetes.zip --compatible-runtimes python3.9 --region ${AWS_REGION}
 

--- a/auroraglobaldb_eks.sh
+++ b/auroraglobaldb_eks.sh
@@ -23,7 +23,7 @@ function install_packages()
 
     curl -s https://raw.githubusercontent.com/aws-samples/aws-swb-cloud9-init/mainline/cloud9-resize.sh > /tmp/cloud9-resize.sh
     chmod +x /tmp/cloud9-resize.sh
-    /tmp/cloud9-resize.sh
+    /tmp/cloud9-resize.sh > ${TERM1} 2>&1
 
     print_line
     echo "Installing aws cli v2"

--- a/auroraglobaldb_eks.sh
+++ b/auroraglobaldb_eks.sh
@@ -214,6 +214,12 @@ function deploy_vpc_c9()
 {
 
     print_line
+    echo "Increasing size of the cloud9 storage"
+    print_line
+
+    source <(curl -s https://raw.githubusercontent.com/aws-samples/aws-swb-cloud9-init/mainline/cloud9-resize.sh)
+
+    print_line
     echo "Deploying VPC and C9 environment"
     print_line
 

--- a/auroraglobaldb_eks.sh
+++ b/auroraglobaldb_eks.sh
@@ -31,6 +31,14 @@ function install_packages()
     unzip -o awscliv2.zip > ${TERM1} 2>&1
     sudo ./aws/install --update > ${TERM1} 2>&1
     cd $current_dir
+
+    print_line
+    echo "Increasing size of the cloud9 storage"
+    print_line
+
+    curl -s https://raw.githubusercontent.com/aws-samples/aws-swb-cloud9-init/mainline/cloud9-resize.sh > /tmp/cloud9-resize.sh
+    chmod +x /tmp/cloud9-resize.sh
+    /tmp/cloud9-resize.sh
 }
 
 function install_k8s_utilities()
@@ -213,13 +221,6 @@ function wait_for_stack_to_complete()
 function deploy_vpc_c9()
 {
 
-    print_line
-    echo "Increasing size of the cloud9 storage"
-    print_line
-
-    curl -s https://raw.githubusercontent.com/aws-samples/aws-swb-cloud9-init/mainline/cloud9-resize.sh > /tmp/cloud9-resize.sh
-    chmod +x /tmp/cloud9-resize.sh
-    /tmp/cloud9-resize.sh
 
     print_line
     echo "Deploying VPC and C9 environment"

--- a/cfn/aurora_gdb.yaml
+++ b/cfn/aurora_gdb.yaml
@@ -59,15 +59,10 @@ Parameters:
   DBEngineVersion:
     Description: Select Database Engine Version
     Type: String
-    Default: 13.3
+    Default: 14.6
     AllowedValues:
-      - 10.16
-      - 10.17
-      - 11.11
-      - 11.12
-      - 12.6
-      - 12.7
-      - 13.3
+      - 13.7
+      - 14.6
 
   Application:
     Description: 'Specify Application Name'

--- a/cfn/aurora_gdb.yaml
+++ b/cfn/aurora_gdb.yaml
@@ -59,9 +59,9 @@ Parameters:
   DBEngineVersion:
     Description: Select Database Engine Version
     Type: String
-    Default: 14.6
+    Default: 13.9
     AllowedValues:
-      - 13.7
+      - 13.9
       - 14.6
 
   Application:

--- a/cfn/aurora_vpc_region.yaml
+++ b/cfn/aurora_vpc_region.yaml
@@ -116,9 +116,9 @@ Parameters:
   DBEngineVersion:
     Description: Select Database Engine Version
     Type: String
-    Default: 14.6
+    Default: 13.9
     AllowedValues:
-      - 13.8
+      - 13.9
       - 14.6
 
   DBInstanceClass:

--- a/cfn/aurora_vpc_region.yaml
+++ b/cfn/aurora_vpc_region.yaml
@@ -116,15 +116,10 @@ Parameters:
   DBEngineVersion:
     Description: Select Database Engine Version
     Type: String
-    Default: 13.3
+    Default: 14.6
     AllowedValues:
-      - 10.16
-      - 10.17
-      - 11.11
-      - 11.12
-      - 12.6
-      - 12.7
-      - 13.3
+      - 13.8
+      - 14.6
 
   DBInstanceClass:
     Default: db.r5.large

--- a/retailapp/kart/Dockerfile
+++ b/retailapp/kart/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:latest
+FROM amazonlinux:2
 
 ENV DATABASE_HOST="xyz.com"
 ENV DATABASE_USER="xyzuser"

--- a/retailapp/order/Dockerfile
+++ b/retailapp/order/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:latest
+FROM amazonlinux:2
 
 ENV DATABASE_HOST="xyz.com"
 ENV DATABASE_USER="xyzuser"

--- a/retailapp/pgbouncer/Dockerfile
+++ b/retailapp/pgbouncer/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:latest
+FROM amazonlinux:2
 
 ENV PGBOUNCER_VERSION="1.17.0"
 ENV DBUSER=${DBUSER:-postgres}

--- a/retailapp/product/Dockerfile
+++ b/retailapp/product/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:latest
+FROM amazonlinux:2
 
 ENV DATABASE_HOST="xyz.com"
 ENV DATABASE_USER="xyzuser"

--- a/retailapp/user/Dockerfile
+++ b/retailapp/user/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:latest
+FROM amazonlinux:2
 
 ENV DATABASE_HOST="xyz.com"
 ENV DATABASE_USER="xyzuser"

--- a/retailapp/webapp/Dockerfile
+++ b/retailapp/webapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:latest
+FROM amazonlinux:2
 
 ENV DATABASE_HOST="xyz.com"
 ENV DATABASE_USER="xyzuser"


### PR DESCRIPTION
*Issue #, if available:*
The latest amazonlinux image does not have amazon-linux-extras package which is breaking the build
The default aurora version 13.3 is not available as a version option

*Description of changes:*
Fixed the amazonlinux image version to 2
Changed the default version of the global database to 13.9

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
